### PR TITLE
Allowing custom modules to be added while in local dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ x-volumes:
       - ./tests/behat/features:/app/web/tests/behat/features:${VOLUME_FLAGS:-delegated}
       - ./tests/phpunit/tests:/app/web/tests/phpunit/tests:${VOLUME_FLAGS:-delegated}
       - ./config:/app/config
+      - ./modules:/app/web/modules/custom:${VOLUME_FLAGS:-delegated}
 
 x-environment:
   &default-environment


### PR DESCRIPTION
While working on GovCMS 8 in my local, I need some custom modules - primarily for development reasons.
For example, devel and devel_generate help me to work on features requiring some content, I can generate content, terms, users easily.
At the moment GovCMS8 has no way of adding those modules.

This PR introduces a directory /modules/ along with a docker-compose mountable volume. Any module that I place into /modules/ directory locally available for my development.

This PR should be considered from the point of Lagoon deployment and is likely requires a custom task of removing either the /modules/* directories from the build artifact or altering the docker-compose.yml, removing the volume definition.