### PR TITLE
Allow extension of ahoy commands.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -138,3 +138,8 @@ commands:
         false
       fi
     hide: true
+
+  custom:
+    usage: Additional project-specific commands.
+    imports:
+      - custom/.ahoy.yml

--- a/custom/.ahoy.yml
+++ b/custom/.ahoy.yml
@@ -1,0 +1,9 @@
+---
+ahoyapi: v2
+usage: Project specific ahoy commands.
+
+# These can be extended with no effect on the govcms platform build.
+commands:
+  example-command:
+    usage: Do something. Run with `ahoy custom example-command` from the repository root.
+    cmd: echo "Hello world"


### PR DESCRIPTION
Allow `ahoy custom example-command`

I'm using the ./custom folder based on other conversations around locally extending stuff, but maybe `ahoy loc command` would be nicer