### PR TITLE
Added 'ahoy debug' command.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -128,6 +128,12 @@ commands:
     usage: Run site audit
     cmd: docker-compose exec -T test drutiny profile:run ci @self "$@"
 
+  debug:
+    usage: Enable debug configuration.
+    cmd: |
+      { ahoy run "php -v|grep -q Xdebug" && echo "Debug is already enabled"; } \
+      || { export XDEBUG_ENABLE="true" && ahoy up && ahoy run "php -v|grep -q Xdebug" && echo "Enabled debug configuration. Use 'ahoy up' to disable."; }
+
   confirm:
     cmd: |
       read -r -p "$@ [y/N] " response

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -132,7 +132,7 @@ commands:
     usage: Enable debug configuration.
     cmd: |
       { ahoy run "php -v|grep -q Xdebug" && echo "Debug is already enabled"; } \
-      || { export XDEBUG_ENABLE="true" && ahoy up && ahoy run "php -v|grep -q Xdebug" && echo "Enabled debug configuration. Use 'ahoy up' to disable."; }
+      || { export XDEBUG_ENABLE="true" && ahoy up cli test php && ahoy run "php -v|grep -q Xdebug" && echo "Enabled debug configuration. Use 'ahoy up' to disable."; }
 
   confirm:
     cmd: |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ The GovCMS projects have been designed to be able to import a nightly copy of th
 * Tests specific to your site can be committed to the `/tests` folders
 * The files folder is not (currently) committed to GitLab.
 * Do not make changes to `docker-compose.yml`, `lagoon.yml`, `.gitlab-ci.yml` or the Dockerfiles under `/.docker` - these will result in your project being unable to deploy to GovCMS SaaS
+* When required, enable Xdebug by running:
+ 
+        Mac/Linux:  ahoy debug
+        Windows:    XDEBUG_ENABLE="true" docker-compose up -d
 
 ## Image inheritance
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,9 @@ x-environment:
     LAGOON_ROUTE: &default-url ${LOCALDEV_URL:-http://govcms8-saas.docker.amazee.io}
     DEV_MODE: ${DEV_MODE:-false}
     X_FRAME_OPTIONS: ${X_FRAME_OPTIONS:-SameOrigin}
+    # Allow to override docker host used from the inside of the containers.
+    DOCKERHOST: ${DOCKERHOST:-}
+    XDEBUG_ENABLE: ${XDEBUG_ENABLE:-}
 
 services:
 


### PR DESCRIPTION
Resolves hectic workflow of modifying `docker-compose.yml` file any time Xdebug session is required.

- Run `ahoy debug` to enable debug session (this will restart containers).
- Run `ahoy up` to disable debug session (this will restart containers).