### PR TITLE
Fail deployment on failed docker stack in 'ahoy build'.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -21,7 +21,7 @@ commands:
 
   build:
     usage: Build project.
-    cmd: docker-compose up -d --build "$@"; ahoy govcms-deploy
+    cmd: docker-compose up -d --build "$@" && ahoy govcms-deploy
 
   cli:
     usage: Start a shell inside cli container.


### PR DESCRIPTION
When docker stack cannot be built, the deployment should not continue.