### PR TITLE
Added 'ahoy info' command.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -21,7 +21,7 @@ commands:
 
   build:
     usage: Build project.
-    cmd: docker-compose up -d --build "$@"; ahoy govcms-deploy
+    cmd: docker-compose up -d --build "$@"; ahoy govcms-deploy && ahoy info
 
   cli:
     usage: Start a shell inside cli container.
@@ -127,6 +127,16 @@ commands:
   audit-site:
     usage: Run site audit
     cmd: docker-compose exec -T test drutiny profile:run ci @self "$@"
+
+  info:
+    usage: Print information about this project.
+    cmd: |
+      echo "Project                  : " $(ahoy run "echo \$LAGOON_PROJECT")
+      echo "Site local URL           : " $(ahoy run "echo \$LOCALDEV_URL")
+      echo "DB port on host          : " $(docker port $(docker-compose ps -q mariadb) 3306 | cut -d : -f 2)
+      if [ "$1" ]; then
+        echo "One-time login           : " $(ahoy login -- --no-browser)
+      fi
 
   confirm:
     cmd: |


### PR DESCRIPTION
Provides verbose information about the project, including DB port on the host.

- When ran as `ahoy info`:
```
Project                  :  agency1
Site local URL           :  http://agency1.docker.amazee.io
DB port on host          :  32792
```

- Added to a `ahoy build` command, so that when built finishes, the information is shown straight away + provides a login link:

```
Project                  :  agency1
Site local URL           :  http://agency1.docker.amazee.io
DB port on host          :  32792
One-time login           :  http://agency1.docker.amazee.io/user/reset/1/1571137655/eDrQKyt7aRBNwXwx3Yv9NvMaSoEiRZ9lh2lhy3X5z_g/login
```

Important to note that:
1. This is just a starter - many more useful information can be provided here
2. The values **always** should come from the inside of the container (except for host-related values, of course).

If https://github.com/govCMS/govcms8-scaffold/pull/21 is accepted - this also can output a state of Xdebug - useful to quickly see whether the stack has Xdebug enabled without restarting with `ahoy up`or checking with `ahoy run "php -v"`.