### PR TITLE
Added removal of dangling volumes on `ahoy down`.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -10,11 +10,11 @@ commands:
     usage: Delete project (CAUTION).
     cmd: |
       if [ "$1" == "y" ]; then
-        docker-compose down
+        docker-compose down --volumes
       else
         ahoy confirm "Running this command will destroy your current site, database and build? Are you sure you didn't mean ahoy stop?" &&
         # Run this if confirm returns true
-        docker-compose down ||
+        docker-compose down --volumes ||
         # Run this if confirm returns false
         echo "OK, probably a wise choice..."
       fi


### PR DESCRIPTION
`docker-compose down` stops and destroys containers, but the **named** volumes are never removed.

For this repository's `docker-compose.yml` we are not using **named** volumes, but developers may specify volumes in `docker-compose.override.yml` (standard docker-compose override config file), which will never be removed, resulting in potentially stale data being used in new local builds.
