### PR TITLE
Fixed 'ahoy run' requiring wrapping all arguments into quotes.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -29,7 +29,7 @@ commands:
 
   run:
     usage: Run command inside cli container.
-    cmd: docker-compose exec -T cli bash -c "$@"
+    cmd: docker-compose exec -T cli bash -c "$*"
 
   govcms-deploy:
     usage: Runs deployment commands (config import, updb, cr, set up file_stage_proxy)


### PR DESCRIPTION
Currently, all arguments to `ahoy run` must be quoted, which is not DX-friendly.
```
ahoy run "composer install"
```

The proposed change allows to pass arguments without quotes:
```
ahoy run composer install
```

Please note that passing options still requires using of `--` (used in bash built-in commands and many other commands to signify the end of command options, after which only positional parameters are accepted)
```
ahoy run -- composer install --ignore-platform-reqs
```

http://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Special-Parameters