### PR TITLE
Prepare v1.1.1 release

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -14,6 +14,6 @@ environments:
 
     cronjobs:
       - name: drush cron
-        schedule: "0 * * * *"
+        schedule: "*/15 * * * *"
         command: 'drush cron --root=/app'
         service: cli

--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -11,8 +11,9 @@ environments:
   master:
     types:
       mariadb: mariadb-shared
+
     cronjobs:
       - name: drush cron
-        schedule: "*/15 * * * *"
-        command: 'drush cron'
+        schedule: "0 * * * *"
+        command: 'drush cron --root=/app'
         service: cli

--- a/.version.yml
+++ b/.version.yml
@@ -1,3 +1,3 @@
 version: 8
 type: saas
-scaffold: 1.0
+scaffold: 1.1.1


### PR DESCRIPTION
## Release v1.1.1
This is the first release using the improved release process, including tagged releases and communicated release notes.

### Release notes
- Bugfix release: Resolves issue where Drush does not always execute in the correct location