### PR TITLE
Point readme to wiki.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,104 +1,22 @@
 # GovCMS8 Project Scaffolding
 
-## Known Issues
+This is a composer project which builds a Drupal 8 GovCMS site ready for
+hosting on the GovCMS platform (Lagoon). If you are a new GovCMS customer
+looking this project on [Github](https://github.com/govCMS/govcms8-scaffold-paas)
+you may wait for the GovCMS service desk to create your own project.
 
-* This repository is still a Work-in-Progress, and may be subject to slight alterations
+For testing you can create a new project by running:
 
-## Requirements and Preliminary Setup
+```
+composer create-project govcms/govcms8-scaffold-paas MY_PROJECT
+```
 
-* [Docker](https://docs.docker.com/install/) - Follow documentation at https://docs.amazee.io/local_docker_development/local_docker_development.html to configure local development environment.
+## Next steps
 
-* [Mac/Linux](https://docs.amazee.io/local_docker_development/pygmy.html) - Make sure you don't have anything running on port 80 on the host machine (like a web server):
+ * [Drupal/GovCMS distribution](https://govcms.gov.au/wiki_distro)
+ * [GovCMS Platform](https://govcms.gov.au/wiki_platform)
 
-        gem install pygmy
-        pygmy up
+## Customising this README
 
-* [Windows](https://docs.amazee.io/local_docker_development/windows.html):    
-
-        git clone https://github.com/amazeeio/amazeeio-docker-windows amazeeio-docker-windows; cd amazeeio-docker-windows
-        docker-compose up -d; cd ..
-
-* [Ahoy (optional)](http://ahoy-cli.readthedocs.io/en/latest/#installation) - The commands are listed in `.ahoy.yml` all include their docker-compose versions for use on Windows, or on systems without Ahoy.
-
-## Project Setup
-
-1. Checkout project repo and confirm the path is in Docker's file sharing config (https://docs.docker.com/docker-for-mac/#file-sharing):
-
-        Mac/Linux: git clone https://www.github.com/govcms/govcms8-scaffold.git {INSERT_PROJECT_NAME} && cd $_
-        Windows:   git clone https://www.github.com/govcms/govcms8-scaffold.git {INSERT_PROJECT_NAME}; cd {INSERT_PROJECT_NAME}
-
-2. Build and start the containers:
-
-        Mac/Linux:  ahoy up
-        Windows:    docker-compose up -d
-
-3. Install GovCMS (only do this if you are building a new site - otherwise see the Databases section below):
-
-        Mac/Linux:  ahoy install
-        Windows:    docker-compose exec -T test drush si -y govcms
-
-4. Login to Drupal:
-
-        Mac/Linux:  ahoy login
-        Windows:    docker-compose exec -T test drush uli
-
-## Commands
-
-Additional commands are listed in `.ahoy.yml`, or available from the command line `ahoy -v`
-
-## Databases
-
-The GovCMS projects have been designed to be able to import a nightly copy of the latest `master` branch database in two ways:
-
-1: Using the GitLab container registry nightly backup
-* these instructions are for https://projects.govcms.gov.au/{org}/{project}/container_registry
-* copy the .env.default file to .env on your local
-* remove the # from in front of #MARIADB_DATA_IMAGE=gitlab-registry-production.govcms.amazee.io/{org}/{project}/mariadb-drupal-data
-* add a GitLab Personal Access Token with `read_registry` scope (profile/personal_access_tokens)
-* `docker login gitlab-registry-production.govcms.amazee.io` (and use the PAT created above as the password)
-* `ahoy up` (or the docker-compose equivalent)
-* to refresh the db with a newer version, run `ahoy up` again
-
-2: Use the backups accessible via the UI
-* head to https://dashboard.govcms.gov.au/backups?name={project}-master
-* click "Prepare download" for the most recent mysql backup you want - note that you will have to refresh the page to see when it is complete.
-* download that backup into your project folder.
-* `ahoy mysql-import` to import the dump you just saved
-
-## Development
-
-* You should create your theme(s) in folders under `/themes`
-* Tests specific to your site can be committed to the `/tests` folders
-* The files folder is not (currently) committed to GitLab.
-* Do not make changes to `docker-compose.yml`, `lagoon.yml`, `.gitlab-ci.yml` or the Dockerfiles under `/.docker` - these will result in your project being unable to deploy to GovCMS SaaS
-
-## Image inheritance
-
-This project is designed to provision a Drupal 8 project onto GovCMS SaaS, using the GovCMS8 distribution, and has been prepared thus
-
-1. The vanilla GovCMS8 Distribution is available at [Github Source](https://github.com/govcms/govcms8) and as [Public DockerHub images](https://hub.docker.com/r/govcms8)
-2. Those GovCMS8 images are then customised for Lagoon and GovCMS, and are available at [Github Source](https://github.com/govcms/govcms8lagoon) and as [Public DockerHub images](https://hub.docker.com/r/govcms8lagoon)
-3. Those GovCMS8lagoon images are then retrieved in this scaffold repository.
-
-## Configuration management
-
-GovCMS8 has default configuration management built in. It assumes all configuration is tracked (in `config/default`).
-
-1. Export latest configuration to `config/default`:
-
-        Mac/Linux:  ahoy cex
-        Windows:    docker-compose exec -T test drush cex sync
-
-2. Import any configuration changes from `config/default`:
-
-        Mac/Linux:  ahoy cim
-        Windows:    docker-compose exec -T test drush cim sync
-
-3. Import development environment configuration overrides:
-
-        Mac/Linux:  ahoy cim dev
-        Windows:    docker-compose exec -T test drush cim dev --partial
-
-
-*Note*: Configuration overrides are snippets of configuration that may be imported over the base configuration. These (optional) files should exist in `config/dev`.
-For example a development project may include a file such as `config/dev/shield.settings.yml` which provides Shield authentication configuration that would only apply to a development environment, not production.
+Once your project is set up, you may wish to customise this README to suit your
+project.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ hosting on the GovCMS platform (Lagoon).
 [Github](https://github.com/govCMS/govcms8-scaffold-paas)
 you may prefer to wait for the GovCMS service desk to create your project in Gitlab.
 
-For testing GovCMS off the platfrom, we recommend that you try our PaaS scaffold
+For testing GovCMS separately to the GovCMS platform, we recommend that you try
+our [PaaS scaffold](https://github.com/govCMS/govcms8-scaffold-paas)
 which has a more conventional Drupal 8 structure.
-[PaaS site](https://github.com/govCMS/govcms8-scaffold-paas).
 
 ## Next steps
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a composer project which builds a Drupal 8 GovCMS **SaaS** site ready fo
 hosting on the GovCMS platform (Lagoon).
 
 **Note**: If you are a new GovCMS customer visiting this page on
-[Github](https://github.com/govCMS/govcms8-scaffold-paas)
+[Github](https://github.com/govCMS/govcms8-scaffold)
 you may prefer to wait for the GovCMS service desk to create your project in Gitlab.
 
 For testing GovCMS separately to the GovCMS platform, we recommend that you try

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # GovCMS8 SaaS Project Scaffolding
 
 This is a composer project which builds a Drupal 8 GovCMS **SaaS** site ready for
-hosting on the GovCMS platform (Lagoon). If you are a new GovCMS customer
-looking this project on [Github](https://github.com/govCMS/govcms8-scaffold-paas)
-you may wait for the GovCMS service desk to create your own project.
+hosting on the GovCMS platform (Lagoon).
 
-For testing GovCMS off the platfrom, we recommend that you use our PaaS scaffold
+**Note**: If you are a new GovCMS customer visiting this page on
+[Github](https://github.com/govCMS/govcms8-scaffold-paas)
+you may prefer to wait for the GovCMS service desk to create your project in Gitlab.
+
+For testing GovCMS off the platfrom, we recommend that you try our PaaS scaffold
 which has a more conventional Drupal 8 structure.
 [PaaS site](https://github.com/govCMS/govcms8-scaffold-paas).
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-# GovCMS8 Project Scaffolding
+# GovCMS8 SaaS Project Scaffolding
 
-This is a composer project which builds a Drupal 8 GovCMS site ready for
+This is a composer project which builds a Drupal 8 GovCMS **SaaS** site ready for
 hosting on the GovCMS platform (Lagoon). If you are a new GovCMS customer
 looking this project on [Github](https://github.com/govCMS/govcms8-scaffold-paas)
 you may wait for the GovCMS service desk to create your own project.
 
-For testing you can create a new project by running:
-
-```
-composer create-project govcms/govcms8-scaffold-paas MY_PROJECT
-```
+For testing GovCMS off the platfrom, we recommend that you use our PaaS scaffold
+which has a more conventional Drupal 8 structure.
+[PaaS site](https://github.com/govCMS/govcms8-scaffold-paas).
 
 ## Next steps
 

--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ which has a more conventional Drupal 8 structure.
 
 ## Customising this README
 
-Once your project is set up, you may wish to customise this README to suit your
-project.
+If you have cloned this project from GovCMS Gitlab, you may customise this README
+with specific information about your site.


### PR DESCRIPTION
This readme is mimimum, however I realised it does need to flag that running `composer create-project ...` is not something they will run if they are a new platform customer.