### PR TITLE
[GOVCMS-4392]: Update the deploy process.

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -16,20 +16,22 @@ environments:
 
 tasks:
   # Pre-rollout tasks do not get called on first deploy; use post-rollout tasks instead.
+  # Pre-rollout tasks need to have file existance checks as these are run in the active
+  # containers and it is not guaranteed that the commands will be available there.
   pre-rollout:
     - run:
         name: Pre-rollout database updates
-        command: /app/vendor/bin/govcms-pre-deploy-db-update
+        command: "[ -f /app/vendor/bin/govcms-pre-deploy-db-update ] && /app/vendor/bin/govcms-pre-deploy-db-update || echo '[govcms-pre-deploy-db-update] is not available.'"
         service: cli
         shell: bash
     - run:
         name: Snapshot the database and store
-        command: /app/vendor/bin/govcms-db-backup
+        command: "if [ -f /app/vendor/bin/govcms-db-backup ] && /app/vendor/bin/govcms-db-backup || echo '[govcms-db-backup] is not available.'"
         service: cli
         shell: bash
     - run:
         name: Snapshot the config and store
-        command: /app/vendor/bin/govcms-config-backup
+        command: "if [ -f /app/vendor/bin/govcms-config-backup ] && /app/vendor/bin/govcms-config-backup || echo '[govcms-config-backup] is not availble.'"
         service: cli
         shell: bash
 

--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -18,66 +18,55 @@ tasks:
   # Pre-rollout tasks do not get called on first deploy; use post-rollout tasks instead.
   pre-rollout:
     - run:
-        name: Ensure backup folder exists - not all current envs have one
-        command: mkdir -p /app/web/sites/default/files/private/backups
+        name: Pre-rollout database updates
+        command: /app/vendor/bin/pre-deploy-update-database
         service: cli
-        shell: bash    
+        shell: bash
     - run:
         name: Snapshot the database and store
-        command: if [[ "$LAGOON_ENVIRONMENT_TYPE" = "production" ]]; then drush sql:dump --root=/app --gzip --result-file=/app/web/sites/default/files/private/backups/pre-deploy-dump.sql; fi
+        command: /app/vendor/bin/backup-db
         service: cli
         shell: bash
     - run:
         name: Snapshot the config and store
-        command: if [[ $(drush cex --root=/app sync -y --quiet --destination "$TMP"/config; echo "$?") = 0 ]]; then tar -czf /app/web/sites/default/files/private/backups/pre-deploy-config.tar.gz "$TMP"/config --remove-files; fi
+        command: /app/vendor/bin/backup-config
         service: cli
         shell: bash
 
   post-rollout:
     - run:
-        name: Correct legacy drush alias if necessary
-        command: sed -i "s/%%PROJECT_NAME%%/\${env.LAGOON_PROJECT}/g" /app/drush/sites/govcms.site.yml
+        name: Prepare the site for deployment
+        command: /app/vendor/bin/prepare
         service: cli
         shell: bash
     - run:
-        name: Ensure backups and tmp folders exist
-        command: mkdir -p /app/web/sites/default/files/private/{backups,tmp}
-        service: cli
-        shell: bash
-    - run:
-        name: If a new environment populate database from master
-        command: drush status db-status | grep Connected || if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then drush sql:sync @govcms.prod @self -y; fi
+        name: Synchronise the database
+        command: /app/vendor/bin/db-sync
         service: cli
         shell: bash
     - run:
         name: Perform database updates
-        command: drush -y updatedb
+        command: /app/vendor/bin/update-database
         service: cli
         shell: bash
     - run:
-        name: Perform config import (uncomment to enable)
-        command: |
-          # drush cim -y sync && if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then drush cim -y --partial --source=../config/dev; fi
+        name: Perform config import
+        command: /app/vendor/bin/config-import
         service: cli
         shell: bash
     - run:
         name: Perform cache rebuild
-        command: drush -y cr
+        command: /app/vendor/bin/cache-rebuild
         service: cli
         shell: bash
     - run:
         name: Ensure GovCMS/Lagoon modules are enabled
-        command: drush en -y govcms_lagoon && drush pmu -y govcms_lagoon
-        service: cli
-        shell: bash
-    - run:
-        name: Enable any non-production modules
-        command: if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then drush en stage_file_proxy -y; fi
+        command: /app/vendor/bin/enable-modules
         service: cli
         shell: bash
     - run:
         name: Preserve the last successful backup
-        command: export BACKUP="/app/web/sites/default/files/private/backups/pre-deploy-dump" && mv "$BACKUP.sql.gz" "$BACKUP-last-good.sql.gz" || true
+        command: /app/vendor/bin/preserve-backups
         service: cli
         shell: bash
 

--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -19,24 +19,24 @@ tasks:
   pre-rollout:
     - run:
         name: Pre-rollout database updates
-        command: /app/vendor/bin/govcms-pre-deploy-update-database
+        command: /app/vendor/bin/govcms-pre-deploy-db-update
         service: cli
         shell: bash
     - run:
         name: Snapshot the database and store
-        command: /app/vendor/bin/govcms-backup-db
+        command: /app/vendor/bin/govcms-db-backup
         service: cli
         shell: bash
     - run:
         name: Snapshot the config and store
-        command: /app/vendor/bin/govcms-backup-config
+        command: /app/vendor/bin/govcms-config-backup
         service: cli
         shell: bash
 
   post-rollout:
     - run:
         name: Prepare the site for deployment
-        command: /app/vendor/bin/govcms-prepare
+        command: /app/vendor/bin/govcms-update_site_alias
         service: cli
         shell: bash
     - run:
@@ -46,7 +46,7 @@ tasks:
         shell: bash
     - run:
         name: Perform database updates
-        command: /app/vendor/bin/govcms-update-database
+        command: /app/vendor/bin/govcms-db-update
         service: cli
         shell: bash
     - run:
@@ -61,12 +61,12 @@ tasks:
         shell: bash
     - run:
         name: Ensure GovCMS/Lagoon modules are enabled
-        command: /app/vendor/bin/govcms-enable-modules
+        command: /app/vendor/bin/govcms-enable_modules
         service: cli
         shell: bash
     - run:
         name: Preserve the last successful backup
-        command: /app/vendor/bin/govcms-preserve-backups
+        command: /app/vendor/bin/govcms-backups-preserve
         service: cli
         shell: bash
 

--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -19,22 +19,24 @@ tasks:
   # Pre-rollout tasks need to have file existance checks as these are run in the active
   # containers and it is not guaranteed that the commands will be available there.
   pre-rollout:
-    - run:
+    -
+      run:
         name: Pre-rollout database updates
-        command: "[ -f /app/vendor/bin/govcms-pre-deploy-db-update ] && /app/vendor/bin/govcms-pre-deploy-db-update || echo '[govcms-pre-deploy-db-update] is not available.'"
+        command: "[ -f /app/vendor/bin/govcms-pre-deploy-db-update ] && /app/vendor/bin/govcms-pre-deploy-db-update || echo 'Pre Update databse is not available.'"
         service: cli
         shell: bash
-    - run:
+    -
+      run:
         name: Snapshot the database and store
-        command: "if [ -f /app/vendor/bin/govcms-db-backup ] && /app/vendor/bin/govcms-db-backup || echo '[govcms-db-backup] is not available.'"
+        command: "[ -f /app/vendor/bin/govcms-db-backup ] && /app/vendor/bin/govcms-db-backup || echo 'Database backup is not available.'"
         service: cli
         shell: bash
-    - run:
+    -
+      run:
         name: Snapshot the config and store
-        command: "if [ -f /app/vendor/bin/govcms-config-backup ] && /app/vendor/bin/govcms-config-backup || echo '[govcms-config-backup] is not availble.'"
+        command: "[ -f /app/vendor/bin/govcms-config-backup ] && /app/vendor/bin/govcms-config-backup || echo 'Config backup is not available.'"
         service: cli
         shell: bash
-
   post-rollout:
     - run:
         name: Prepare the site for deployment
@@ -71,4 +73,3 @@ tasks:
         command: /app/vendor/bin/govcms-backups-preserve
         service: cli
         shell: bash
-

--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -19,54 +19,54 @@ tasks:
   pre-rollout:
     - run:
         name: Pre-rollout database updates
-        command: /app/vendor/bin/pre-deploy-update-database
+        command: /app/vendor/bin/govcms-pre-deploy-update-database
         service: cli
         shell: bash
     - run:
         name: Snapshot the database and store
-        command: /app/vendor/bin/backup-db
+        command: /app/vendor/bin/govcms-backup-db
         service: cli
         shell: bash
     - run:
         name: Snapshot the config and store
-        command: /app/vendor/bin/backup-config
+        command: /app/vendor/bin/govcms-backup-config
         service: cli
         shell: bash
 
   post-rollout:
     - run:
         name: Prepare the site for deployment
-        command: /app/vendor/bin/prepare
+        command: /app/vendor/bin/govcms-prepare
         service: cli
         shell: bash
     - run:
         name: Synchronise the database
-        command: /app/vendor/bin/db-sync
+        command: /app/vendor/bin/govcms-db-sync
         service: cli
         shell: bash
     - run:
         name: Perform database updates
-        command: /app/vendor/bin/update-database
+        command: /app/vendor/bin/govcms-update-database
         service: cli
         shell: bash
     - run:
         name: Perform config import
-        command: /app/vendor/bin/config-import
+        command: /app/vendor/bin/govcms-config-import
         service: cli
         shell: bash
     - run:
         name: Perform cache rebuild
-        command: /app/vendor/bin/cache-rebuild
+        command: /app/vendor/bin/govcms-cache-rebuild
         service: cli
         shell: bash
     - run:
         name: Ensure GovCMS/Lagoon modules are enabled
-        command: /app/vendor/bin/enable-modules
+        command: /app/vendor/bin/govcms-enable-modules
         service: cli
         shell: bash
     - run:
         name: Preserve the last successful backup
-        command: /app/vendor/bin/preserve-backups
+        command: /app/vendor/bin/govcms-preserve-backups
         service: cli
         shell: bash
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ which has a more conventional Drupal 8 structure.
 
  * [Drupal/GovCMS distribution](https://govcms.gov.au/wiki-distro)
  * [GovCMS Platform](https://govcms.gov.au/wiki-platform)
+ * [GovCMS Maintenance](https://govcms.gov.au/wiki-maintenance)
+ * [GovCMS release process](https://github.com/govCMS/govcms8-scaffold-paas/wiki/Update-process)
+
 
 ## Customising this README
 


### PR DESCRIPTION
GovCMS base images now include the scaffold-tooling dependency, this installs deploy
scripts to the /app/vendor/bin directory and will allow us to align approaches and
centrally manage updates to the deployment process.

- Align the deploy process with the scaffold tooling approach.

**Testing**
- govcms8lagoon was pinned to the scaffold-tooling feature which included the separated scripts
- govcms8lagoon edge images were built
- Scaffold update ansible task was run against a few canary projects (vanilla-govcms8-beta, vanilla-govcms8-test)
- These environments were deployed and tested