### PR TITLE
add prod env check to post-rollout backup cycle

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -77,7 +77,7 @@ tasks:
         shell: bash
     - run:
         name: Preserve the last successful backup
-        command: export BACKUP="/app/web/sites/default/files/private/backups/pre-deploy-dump" && mv "$BACKUP.sql.gz" "$BACKUP-last-good.sql.gz" || true
+        command: if [[ "$LAGOON_ENVIRONMENT_TYPE" = "production" ]]; then export BACKUP="/app/web/sites/default/files/private/backups/pre-deploy-dump" && mv "$BACKUP.sql.gz" "$BACKUP-last-good.sql.gz" || true; fi
         service: cli
         shell: bash
 


### PR DESCRIPTION
This should make it into a hotfix release - which should only be deployed to projects running scaffold v1.1.3 or v1.1.4