### PR TITLE
Ensures solr image uses image version var.

### DIFF
--- a/.docker/Dockerfile.solr
+++ b/.docker/Dockerfile.solr
@@ -1,0 +1,7 @@
+##
+# @see /.docker/README.md
+#
+
+ARG GOVCMS_IMAGE_VERSION=latest
+
+FROM govcms8lagoon/solr:${GOVCMS_IMAGE_VERSION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,17 +109,9 @@ services:
     environment:
       << : *default-environment
 
-  # Lodge a support ticket to have Redis enabled.
-  # redis:
-  #   image: govcms8lagoon/redis
-  #   labels:
-  #     lagoon.type: redis
-  #   environment:
-  #     << : *default-environment
-
-  # Lodge a support ticket to have Solr enabled.
+  # Lodge a support ticket to have Solr search enabled.
   # solr:
-  #   image: govcms8lagoon/solr
+  #   image: govcms8lagoon/solr:${GOVCMS_IMAGE_VERSION:-latest}
   #   labels:
   #     lagoon.type: solr
   #   ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,11 @@ services:
 
   # Lodge a support ticket to have Solr search enabled.
   # solr:
-  #   image: govcms8lagoon/solr:${GOVCMS_IMAGE_VERSION:-latest}
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Dockerfile.solr
+  #     args:
+  #       GOVCMS_IMAGE_VERSION: *govcms-image-version
   #   labels:
   #     lagoon.type: solr
   #   ports:


### PR DESCRIPTION
- Ensures the solr image listens to the `GOVCMS_IMAGE_VERSION` variable.
- Removes redis, we do not support single-pod Redis anymore.