### PR TITLE
[GOVCMS-5388]: Add notifications to drush cron.

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -5,9 +5,9 @@ environments:
     types:
       mariadb: mariadb-shared
     cronjobs:
-      - name: drush cron
+      - name: Drupal cron with notifications
         schedule: "0 * * * *"
-        command: 'drush cron --root=/app'
+        command: '/app/vendor/bin/govcms-drush cron --root=/app'
         service: cli
 
 # Note regarding tasks in the scaffold.


### PR DESCRIPTION
- Updates the drush cron call to use the govcms wrapper to catch errors and send notifications